### PR TITLE
Feature/makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+install:
+	opam install . --deps-only --with-test
+build:
+	dune build
+run:
+	dune exec ./app/capymanga/bin/main.exe

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cd capy
 5. Install capymanga's dependencies:
 
 ```sh
-make install
+opam install . --deps-only --with-test
 ```
 
 6. Build capymanga with [dune](https://dune.build/). `dune` is OCaml's "build
@@ -58,7 +58,7 @@ make install
    `dune` to build capymanga with:
 
 ```sh
-make build
+dune build
 ```
 
 7. Assuming that the above step succeeded, `dune` will place the things it
@@ -66,5 +66,8 @@ make build
    capymanga with:
 
 ```sh
-make run
+./_build/default/app/capymanga/bin/main.exe
 ```
+
+8. For convenience, rather than typing the long path each time, you can also run
+   `make run` to run capymanga.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cd capy
 5. Install capymanga's dependencies:
 
 ```sh
-opam install . --deps-only --with-test
+make install
 ```
 
 6. Build capymanga with [dune](https://dune.build/). `dune` is OCaml's "build
@@ -58,7 +58,7 @@ opam install . --deps-only --with-test
    `dune` to build capymanga with:
 
 ```sh
-dune build
+make build
 ```
 
 7. Assuming that the above step succeeded, `dune` will place the things it
@@ -66,5 +66,5 @@ dune build
    capymanga with:
 
 ```sh
-./_build/default/app/capymanga/bin/main.exe
+make run
 ```


### PR DESCRIPTION
* Add makefile to install, build, and run capymanga
* Update README to reflect the usage of make

Originally, I was going to append something like
```
or run

make install
```

to the README. Let me know if you'd rather me take out the README commit, squash the commits, or if you have any edits as well 